### PR TITLE
remove unnecessary lynt ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "jest",
-    "lint": "lynt --react --ignore dist --env jest",
+    "lint": "lynt --react --env jest",
     "fmt": "prettier --write **/*.{js,json,css,md}",
     "precommit": "pretty-quick --staged"
   },


### PR DESCRIPTION
Hey there, I'm the creator of `lynt`. Thanks for checking out my package!

My README was a bit misleading by giving examples that involved having an `--ignore dist`. However, this folder is already ignored by default so it is unnecessary to provide an additional `--ignore` for it.

The list of default ignores is here: https://github.com/saadq/lynt/blob/master/src/eslint/config.ts#L25-L36

I'm going to improve my README to make this  more apparent.