### PR TITLE
Remove unnecessary step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Just execute the following three lines for executing, generating and deploying s
 ```sh
 $ npm i fusuma -D
 $ npx fusuma init
-$ mkdir slides && touch slides/title.md && echo '# Hello😄' > slides/title.md
+$ mkdir slides && echo '# Hello😄' > slides/title.md
 
 # --- Tree ---
 $ tree -a


### PR DESCRIPTION
Hello @hiroppy , thanks for the awesome tool.

I just removed an unnecessary step in README because a redirect of shell (`>`) creates a file by default. Besides, it doesn't correctly write a content in the file like below in some environment.

```
$ mkdir slides && touch slides/title.md && echo '# Hello😄' > slides/title.md
zsh: file exists: slides/title.md
```