### PR TITLE
chore: add online demo using Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+ports:
+  - port: 8080
+    onOpen: open-preview
+tasks:
+  - before: npm link
+    command: cd samples/intro && npx fusuma start

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Just write MarkDown and create cool slides.😎
 - [introduction slide of Fusuma](https://hiroppy.github.io/fusuma/intro) [[repository](/samples/intro)]
 - others [[repository](https://github.com/hiroppy/slides#my-slides)]
 
+You can also try Fusuma in Gitpod, a one-click online IDE for GitHub:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/hiroppy/fusuma/blob/master/samples/intro/slides/0-title.md)
+
 ## Install
 
 Node versions > v8

--- a/__tests__/src/webpack/__snapshots__/webpack.config.js.snap
+++ b/__tests__/src/webpack/__snapshots__/webpack.config.js.snap
@@ -4,6 +4,7 @@ exports[`webpack.config should return settings when NODE_ENV is development 1`] 
 Object {
   "devServer": Object {
     "contentBase": ".",
+    "disableHostCheck": true,
     "hot": true,
     "inline": true,
     "port": 8080,

--- a/__tests__/src/webpack/__snapshots__/webpack.dev.config.js.snap
+++ b/__tests__/src/webpack/__snapshots__/webpack.dev.config.js.snap
@@ -4,6 +4,7 @@ exports[`webpack.dev should match settings 1`] = `
 Object {
   "devServer": Object {
     "contentBase": ".",
+    "disableHostCheck": true,
     "hot": true,
     "inline": true,
     "port": 8080,

--- a/src/webpack/webpack.dev.config.js
+++ b/src/webpack/webpack.dev.config.js
@@ -14,7 +14,8 @@ function dev() {
       port: 8080,
       quiet: true,
       inline: true,
-      contentBase: '.'
+      contentBase: '.',
+      disableHostCheck: true
     },
     plugins: [new FriendlyErrorsWebpackPlugin()]
   };


### PR DESCRIPTION
👋 Hi!

Thanks a lot for making a cool Markdown slide deck! (This is exactly what I needed--now I can stop reinventing a new slide system every time I give a talk! 😅)

I work on gitpod.io, a one-click online IDE for GitHub, and I'd like to contribute an online demo for Fusuma where you can edit Markdown files and see the result live.

Here is what it looks like:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/13db9d48-cf3b-4857-867e-623731a33a83)
<img width="1552" alt="Screenshot 2019-05-09 at 16 14 55" src="https://user-images.githubusercontent.com/599268/57462253-d06da780-7278-11e9-97d1-172cfebbd2ef.png">
Please let me know what you think. 🙂 