### PR TITLE
feat(webpack): adds port option to webpack-dev-server

### DIFF
--- a/packages/cli/src/fusuma.js
+++ b/packages/cli/src/fusuma.js
@@ -24,10 +24,11 @@ async function cli() {
 
       .command('start', 'Start with webpack-dev-server')
       .option('-d <directory>', 'Directory to load')
+      .option('-p <port>', 'Server port', prog.INT, 8080)
       .action((args, options, logger) => {
         resolve({
           type: 'start',
-          options: { dir: options.d }
+          options: { dir: options.d, port: options.p }
         });
       })
 

--- a/packages/webpack/__tests__/webpack.dev.config.js
+++ b/packages/webpack/__tests__/webpack.dev.config.js
@@ -2,6 +2,6 @@ const dev = require('../src/webpack.dev.config');
 
 describe('webpack.dev', () => {
   test('should match settings', () => {
-    expect(dev()).toMatchSnapshot();
+    expect(dev({ port: 8080 })).toMatchSnapshot();
   });
 });

--- a/packages/webpack/src/webpack.config.js
+++ b/packages/webpack/src/webpack.config.js
@@ -36,7 +36,7 @@ module.exports = ({
 
   const config =
     process.env.NODE_ENV !== 'production'
-      ? require('./webpack.dev.config')()
+      ? require('./webpack.dev.config')(server)
       : require('./webpack.prod.config')();
 
   const common = {

--- a/packages/webpack/src/webpack.dev.config.js
+++ b/packages/webpack/src/webpack.dev.config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function dev() {
+function dev(serverConfig) {
   const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 
   return {
@@ -11,7 +11,7 @@ function dev() {
     },
     devServer: {
       hot: true,
-      port: 8080,
+      port: serverConfig.port,
       quiet: true,
       inline: true,
       contentBase: '.',


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

- [ ] bugfix
- [x] feature
- [ ] code refactor
- [ ] test update
- [ ] docs update
- [x] chore update

### Motivation / Use-Case
The 8080 port of webpack-dev-server is conflicted to other projects so often, It'd be great if it's possible to change by option like live-task.