### PR TITLE
modify code block font size

### DIFF
--- a/packages/client/assets/style/common.css
+++ b/packages/client/assets/style/common.css
@@ -46,8 +46,14 @@ code {
 
 code[class*='language-'],
 pre[class*='language-'] {
-  font-size: 20px;
+  font-size: 1.4rem;
   line-height: 1.2;
+}
+@media screen and (min-width: 768px) {
+  code[class*='language-'],
+  pre[class*='language-'] {
+    font-size: 2rem;
+  }
 }
 
 #root {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

- [ ] bugfix
- [ ] feature
- [ ] code refactor
- [ ] test update
- [ ] docs update
- [x] chore update

### Motivation / Use-Case

 Code block font-size is too large to read when viewed on a smartphone.

#### before

[![Image from Gyazo](https://i.gyazo.com/76f80228691cb2347712321943b9b5b4.png)](https://gyazo.com/76f80228691cb2347712321943b9b5b4)

#### after

[![Image from Gyazo](https://i.gyazo.com/056bd5464e7e76433e21ec66cfdfd6ba.png)](https://gyazo.com/056bd5464e7e76433e21ec66cfdfd6ba)