### PR TITLE
fix: resolve edge-case of webpack base-path resolution

### DIFF
--- a/packages/webpack/src/webpack.config.js
+++ b/packages/webpack/src/webpack.config.js
@@ -10,11 +10,11 @@ const { babel: babelrc } = require('@fusuma/configs');
 const css = require('./css');
 
 const configsEntryPoint = require.resolve('@fusuma/configs');
-const configsBasePath = configsEntryPoint.split('/src')[0];
+const configsBasePath = configsEntryPoint.split('/src').slice(0, -1).join('/src');
 const clientEntryPoint = require.resolve('@fusuma/client');
-const clientBasePath = clientEntryPoint.split('/src')[0];
+const clientBasePath = clientEntryPoint.split('/src').slice(0, -1).join('/src');
 const mdxLoaderEntryPoint = require.resolve('@fusuma/mdx-loader');
-const mdxLoaderBasePath = mdxLoaderEntryPoint.split('/src')[0];
+const mdxLoaderBasePath = mdxLoaderEntryPoint.split('/src').slice(0, -1).join('/src');
 
 module.exports = (type, { meta, slide, extends: fileExtends, internal = {}, server = {} }) => {
   // name is deprecated TODO: delete


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

- [x] bugfix
- [ ] feature
- [ ] code refactor
- [ ] test update
- [ ] docs update
- [ ] chore update

### Motivation / Use-Case

In working directory path, if `/src` appear twice or over, module resolution path in @fusuma/webpack will fail.

e.g. work at `/home/euxn/src/my-slide`, @fusuma/webpack parse `/home/euxn/src/my-slide/node_modules/@fusuma/config/src/index.js` into `/home/euxn`, expected is `/home/euxn/src/my-slide/node_modules/@fusuma/config`.