### PR TITLE
fix(mdx): not replacing all img src

### DIFF
--- a/packages/mdx-loader/__tests__/__snapshots__/index.js.snap
+++ b/packages/mdx-loader/__tests__/__snapshots__/index.js.snap
@@ -466,6 +466,53 @@ export default function MDXContent({
 MDXContent.isMDXComponent = true;"
 `;
 
+exports[`fusuma-loader should convert all img src 1`] = `
+"/* @jsx mdx */
+
+
+        import React from 'react';
+        import { mdx } from '@mdx-js/react';
+        export const slides = [
+          (props) => (
+            <>
+              
+    <h1>{\`img src\`}</h1>
+    <div>
+  <img src={require(\\"random.gif\\")} alt=\\"random\\" />
+  <img src={require(\\"random2.png\\")} alt=\\"random2\\" />
+  <img src={require(\\"random3.svg\\")} alt=\\"random3\\" />
+    </div>
+    
+            </>
+          )];
+        export const fusumaProps = [{}];
+const makeShortcode = name => function MDXDefaultShortcode(props) {
+  console.warn(\\"Component \\" + name + \\" was not imported, exported, or provided by MDXProvider as global scope\\")
+  return <div {...props}/>
+};
+
+const layoutProps = {
+  slides
+};
+const MDXLayout = \\"wrapper\\"
+export default function MDXContent({
+  components,
+  ...props
+}) {
+  return <MDXLayout {...layoutProps} {...props} components={components} mdxType=\\"MDXLayout\\">
+    <h1>{\`img src\`}</h1>
+    <div>
+  <img src={require(\\"random.gif\\")} alt=\\"random\\" />
+  <img src={require(\\"random2.png\\")} alt=\\"random2\\" />
+  <img src={require(\\"random3.svg\\")} alt=\\"random3\\" />
+    </div>
+
+    </MDXLayout>;
+}
+
+MDXContent.isMDXComponent = true;"
+`;
+
 exports[`fusuma-loader should convert class to className 1`] = `
 "/* @jsx mdx */
 

--- a/packages/mdx-loader/__tests__/index.js
+++ b/packages/mdx-loader/__tests__/index.js
@@ -100,6 +100,19 @@ $$
     expect(await transformToJS(src)).toMatchSnapshot();
   });
 
+  test('should convert all img src', async () => {
+    const src = `
+# img src
+
+<div>
+  <img src="random.gif" alt="random"/>
+  <img src="random2.png" alt="random2"/>
+  <img src="random3.svg" alt="random3"/>
+</div>
+`;
+    expect(await transformToJS(src)).toMatchSnapshot();
+  });
+
   test('should convert class to className', async () => {
     const src = `
 # Class

--- a/packages/mdx-loader/src/mdxPlugin.js
+++ b/packages/mdx-loader/src/mdxPlugin.js
@@ -119,7 +119,7 @@ function mdxPlugin() {
 
         if (n.type === 'jsx') {
           n.value = n.value
-            .replace(/src="(.+?\.(png|jpg|gif|svg?))"/, 'src={require("$1")}')
+            .replace(/src="(.+?\.(png|jpg|gif|svg?))"/g, 'src={require("$1")}')
             .replace(/class=/g, 'className=');
         }
       }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

- [x] bugfix
- [ ] feature
- [ ] code refactor
- [x] test update
- [ ] docs update
- [ ] chore update

### Motivation / Use-Case

When there are multiple `img src`s on the one slide. `mdx-loader` only correctly substitute the first src. Subsequent images fails to load.

<img width="817" alt="image" src="https://user-images.githubusercontent.com/1014413/62823598-cc358b00-bbd5-11e9-84fe-6cc0c01fd213.png">
