### PR TITLE
fix: the image wrttien in markdown-syntax `![]()` is not rendered

### DIFF
--- a/packages/mdx-loader/__tests__/__snapshots__/index.js.snap
+++ b/packages/mdx-loader/__tests__/__snapshots__/index.js.snap
@@ -608,6 +608,53 @@ export default function MDXContent({
 MDXContent.isMDXComponent = true;"
 `;
 
+exports[`fusuma-loader should convert markdown-syntax image to JSX 1`] = `
+"/* @jsx mdx */
+
+
+        import React from 'react';
+        import { mdx } from '@mdx-js/react';
+        export const slides = [
+          (props) => (
+            <>
+              
+    <p><img src={require('/tmp/withAlt.jpg')} {...{
+        \\"alt\\": \\"Alt\\"
+      }}></img><br parentName=\\"p\\"></br>{\`
+\`}<img src={require('/tmp/withoutAlt.jpg')} {...{
+        \\"alt\\": null
+      }}></img></p>
+    
+            </>
+          )];
+        export const fusumaProps = [{}];
+const makeShortcode = name => function MDXDefaultShortcode(props) {
+  console.warn(\\"Component \\" + name + \\" was not imported, exported, or provided by MDXProvider as global scope\\")
+  return <div {...props}/>
+};
+
+const layoutProps = {
+  slides
+};
+const MDXLayout = \\"wrapper\\"
+export default function MDXContent({
+  components,
+  ...props
+}) {
+  return <MDXLayout {...layoutProps} {...props} components={components} mdxType=\\"MDXLayout\\">
+    <p><img src={require('/tmp/withAlt.jpg')} {...{
+        \\"alt\\": \\"Alt\\"
+      }}></img><br parentName=\\"p\\"></br>{\`
+\`}<img src={require('/tmp/withoutAlt.jpg')} {...{
+        \\"alt\\": null
+      }}></img></p>
+
+    </MDXLayout>;
+}
+
+MDXContent.isMDXComponent = true;"
+`;
+
 exports[`fusuma-loader should convert mermaid 1`] = `
 "/* @jsx mdx */
 

--- a/packages/mdx-loader/__tests__/__snapshots__/index.js.snap
+++ b/packages/mdx-loader/__tests__/__snapshots__/index.js.snap
@@ -621,9 +621,7 @@ exports[`fusuma-loader should convert markdown-syntax image to JSX 1`] = `
     <p><img src={require('/tmp/withAlt.jpg')} {...{
         \\"alt\\": \\"Alt\\"
       }}></img><br parentName=\\"p\\"></br>{\`
-\`}<img src={require('/tmp/withoutAlt.jpg')} {...{
-        \\"alt\\": null
-      }}></img></p>
+\`}<img src={require('/tmp/withoutAlt.jpg')}></img></p>
     
             </>
           )];
@@ -645,9 +643,7 @@ export default function MDXContent({
     <p><img src={require('/tmp/withAlt.jpg')} {...{
         \\"alt\\": \\"Alt\\"
       }}></img><br parentName=\\"p\\"></br>{\`
-\`}<img src={require('/tmp/withoutAlt.jpg')} {...{
-        \\"alt\\": null
-      }}></img></p>
+\`}<img src={require('/tmp/withoutAlt.jpg')}></img></p>
 
     </MDXLayout>;
 }

--- a/packages/mdx-loader/__tests__/index.js
+++ b/packages/mdx-loader/__tests__/index.js
@@ -138,4 +138,12 @@ second
 `;
     expect(await transformToJS(src)).toMatchSnapshot();
   });
+
+  test('should convert markdown-syntax image to JSX', async () => {
+    const src = `
+![Alt](/tmp/withAlt.jpg)    
+![](/tmp/withoutAlt.jpg)
+`;
+    expect(await transformToJS(src)).toMatchSnapshot();
+  });
 });

--- a/packages/mdx-loader/src/mdxPlugin.js
+++ b/packages/mdx-loader/src/mdxPlugin.js
@@ -56,13 +56,14 @@ function createFusumaProps(nodes) {
 
 function transferMarkdownImageNodeToJSX(node) {
   const hash = mdxAstToMdxHast()(node);
-  const { src } = hash.properties;
+  const { src, alt } = hash.properties;
+  if (alt === null || alt === undefined) delete hash.properties.alt;
   let jsx;
 
   // Do not resolve remote url as a module
   if (src.indexOf('http') < 0) {
     delete hash.properties.src;
-    jsx = toJSX(hash).replace(/<img\s(.*)>/, `<img src={require('${src}')} $1>`);
+    jsx = toJSX(hash).replace(/<img(\s?.*)>/, `<img src={require('${src}')} $1>`);
   } else {
     jsx = toJSX(hash);
   }

--- a/packages/mdx-loader/src/mdxPlugin.js
+++ b/packages/mdx-loader/src/mdxPlugin.js
@@ -137,7 +137,7 @@ function mdxPlugin() {
         }
       } else {
         visit(n, null, (node) => {
-          if (node.type === 'image' || node.type === 'img') {
+          if (node.type === 'image') {
             const { type, value } = transferMarkdownImageNodeToJSX(node);
             node.type = type;
             node.value = value;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

- [x] bugfix
- [ ] feature
- [ ] code refactor
- [x] test update
- [ ] docs update
- [ ] chore update

### Motivation / Use-Case

#### Current behavior
When we use `![]()` syntax on `.md` file, the file path is not resolved correctly.

Input markdown:
```markdown
![sample](../../assets/sample.png)
```

Output html:
```html
<img src="../../assets/sample.png" alt="sample">
```

#### This PR achieves

The image element with markdown syntax:`![]()` would be converted to JSX by mdx-loader like below.

```markdown
![sample](../../assets/sample.png)
```
would be converted to

```jsx
"<img src={require('../../assets/sample.png')} {...{"alt":"sample"}}></img>"
```

Eventually, the image's source is resolved by file-loader and the output will be below.
```html
<img src="xxxxxxxxxxxxxxxxxxxxxxxxxxx.webp" alt="sample">
```

fixes: #198 