### PR TITLE
During slide discovery prefer natural ordering of numbers

### DIFF
--- a/packages/client/src/utils/fetchSlides.js
+++ b/packages/client/src/utils/fetchSlides.js
@@ -8,7 +8,9 @@ export function fetchSlides(dir) {
       id: context.id,
       slides: context
         .keys()
-        .sort()
+        .sort(function(a, b) {
+          return +/\d+/.exec(a)[0] - +/\d+/.exec(b)[0];
+        })
         .map((e) => context(e)),
     };
   }


### PR DESCRIPTION
It's not anymore necessary to use fixed-width numbers (001, 024, 100) to move 24 before 100 during slide loading.

The one liner sort() function is courtesy of https://stackoverflow.com/a/14599441/4620544

Fixes #598

It's necessary to regenerate the cache (node_modules/.cache) for this PR to make effect.

<!-- Thank you for submitting a pull request! -->

- [ ] bugfix
- [X] feature
- [ ] code refactor
- [ ] test update
- [ ] docs update
- [ ] chore update

### Motivation / Use-Case

See #598 for motivation.
