### PR TITLE
fix(webpack): use inputDirPath to definition of $SLIDE_PATH

### DIFF
--- a/packages/fusuma/src/webpack/webpack.config.js
+++ b/packages/fusuma/src/webpack/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = (
   } = slide;
   const { js: jsPath, css: cssPath, webpack: webpackPath } = fileExtends;
   const { useCache, publicPath } = build;
-  const { basePath, remoteOrigin, htmlBody = '', outputDirPath } = internal;
+  const { basePath, remoteOrigin, htmlBody = '', inputDirPath, outputDirPath } = internal;
   const config = (() => {
     switch (type) {
       case 'production':
@@ -161,7 +161,7 @@ module.exports = (
           NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development'),
           JS_PATH: JSON.stringify(join(basePath, jsPath || '')),
           CSS_PATH: JSON.stringify(join(basePath, cssPath || '')),
-          SLIDE_PATH: JSON.stringify(join(basePath, 'slides')),
+          SLIDE_PATH: JSON.stringify(inputDirPath || join(basePath, 'slides')),
           URL: JSON.stringify(url),
           HAS_TWITTER: JSON.stringify(sns.includes('twitter')),
           TITLE: JSON.stringify(title || 'slide'),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

- [x] bugfix
- [ ] feature
- [ ] code refactor
- [ ] test update
- [ ] docs update
- [ ] chore update

### Motivation / Use-Case

I fixed the problem that `$SLIDE_PATH` defined in webpack.config always will be `{baseDir}/slides`  even if inputDir (`-i` option) is given.