### PR TITLE
Proper error message on missing input directory

### DIFF
--- a/packages/fusuma/src/tasks/index.js
+++ b/packages/fusuma/src/tasks/index.js
@@ -17,7 +17,7 @@ async function tasks({ type, options }) {
   let config = {};
 
   if (type !== 'init' && !existsSync(inputDirPath)) {
-    error('preparation', '"slides" directory not found');
+    error('preparation', 'input directory "' + inputDirPath + '" could not be found');
     process.exit(1);
   }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

- [X] bugfix
- [ ] feature
- [ ] code refactor
- [ ] test update
- [ ] docs update
- [ ] chore update

### Motivation / Use-Case

When input directory is not "slides" and it is missing, the error message is misleading.