### PR TITLE
Make line highlighting and numbering straightforward and documented

### DIFF
--- a/packages/mdx-loader/src/mdxPlugin.js
+++ b/packages/mdx-loader/src/mdxPlugin.js
@@ -186,18 +186,22 @@ function mdxPlugin() {
         }
 
         if (meta) {
-          const lines = n.meta.match(/line="(.+?)"/);
+          const line_number = n.meta.match(/numbering="(\d+)"/);
+          const highlight = n.meta.match(/highlight="(.+?)"/);
 
-          if (lines === null) {
+          if (line_number === null && highlight == null) {
             slide.push(n);
           } else {
-            const line = lines[1];
+            const data_start = line_number?.[1];
+            const data_line = highlight?.[1];
             const hash = mdxAstToMdxHast()(n);
 
             slide.push({
               ...n,
               type: 'jsx',
-              value: toJSX(hash).replace('<pre>', `<pre data-line="${line}">`),
+              value: toJSX(hash).replace('<pre>', `<pre ${data_start ? `className="line-numbers" data-start="${data_start}"` : ''}
+                                                        ${data_line ? `data-line="${data_line}"` : ''}
+                                                        ${data_line && data_start ? `data-line-offset="${data_start}"` : ''}>`),
             });
           }
           return;

--- a/site/docs/guides/configuring-fusuma.md
+++ b/site/docs/guides/configuring-fusuma.md
@@ -66,10 +66,28 @@ code:
     - javascript
   plugins: # the default is []
     - line-numbers
+    - line-highlight
   theme: default # the default is default
 ```
 
-See these options for more details. [babel-plugin-prismjs#configuring-the-plugin](https://github.com/mAAdhaTTah/babel-plugin-prismjs#configuring-the-plugin), [Prism.js Playground](https://prismjs.com/test.html#language=markup)
+List of plugin names can be found on [Prism Github page](https://github.com/PrismJS/prism/tree/master/plugins).
+
+Numbering or higlighting one or more lines can be done by using `numbering` and `highlight` meta tags, respectively:
+
+````
+```c++ numbering="2000" highlight="2010-2012,2014"
+
+/* Starts the line numbering from 2000 and highlights lines indicated above */
+/* Either tag is optional */
+
+#include <iostream>
+
+int main() {
+  std::cout << "Hello, World!\n";
+  return 0;
+}
+```
+````
 
 ## extends
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

- [X] bugfix
- [X] feature
- [ ] code refactor
- [ ] test update
- [X] docs update
- [ ] chore update

### Motivation / Use-Case

Line numbering and highlighting in the ` ``` ` block was not straightforward or documented.